### PR TITLE
Dynamic Dimensions and Reaction Term Support

### DIFF
--- a/src/eafe.py
+++ b/src/eafe.py
@@ -38,8 +38,9 @@ def bernoulli1(r, diffusion_value):
 
 def eafe(mesh, diff, conv, reac=None, boundary=None, **kwargs):
 
-    if (reac is not None):
-        print "reaction terms are not yet supported"
+    if (reac is None):
+        def reac(vertex, cell, **kwargs):
+            return 0.0
 
     ##################################################
     # Mesh and FEM space
@@ -78,7 +79,14 @@ def eafe(mesh, diff, conv, reac=None, boundary=None, **kwargs):
 
         for vertex_id in range(0, cell_vertex_count):
             vertex = cell_vertex[vertex_id]
-            local_tensor[vertex_id][vertex_id] = 0.0
+
+            try:
+                local_tensor[vertex_id, vertex_id] = reac(vertex, cell)
+            except:
+                local_tensor[vertex_id, vertex_id] = reac(barycenter)
+
+            local_tensor[vertex_id, vertex_id] *= (cell.volume()
+                                                   / cell_vertex_count)
 
             for edge_id in range(0, cell_vertex_count):
                 if (edge_id == vertex_id):

--- a/src/eafe.py
+++ b/src/eafe.py
@@ -37,6 +37,8 @@ def bernoulli1(r, diffusion_value):
 
 
 def eafe(mesh, diff, conv, reac=None, boundary=None, **kwargs):
+    quadrature_degree = parameters["form_compiler"]["quadrature_degree"]
+    parameters["form_compiler"]["quadrature_degree"] = 2
 
     if (reac is None):
         def reac(vertex, cell, **kwargs):
@@ -105,4 +107,5 @@ def eafe(mesh, diff, conv, reac=None, boundary=None, **kwargs):
         bc = DirichletBC(V, 0.0, boundary)
         bc.apply(A)
 
+    parameters["form_compiler"]["quadrature_degree"] = quadrature_degree
     return A

--- a/test/double_sin_3d_test.py
+++ b/test/double_sin_3d_test.py
@@ -1,0 +1,71 @@
+from dolfin import *
+import numpy as np
+import inspect
+import sys
+import os
+
+current_frame = inspect.getfile(inspect.currentframe())
+current_dir = os.path.dirname(os.path.abspath(current_frame))
+parent_dir = os.path.dirname(current_dir)
+sys.path.insert(0, parent_dir + "/src")
+import eafe
+
+
+def boundary(x, on_boundary):
+    return on_boundary
+
+diffusivity = 1.0E-2
+def diffusion_expression(x):
+    return diffusivity
+
+def convection_expression(x):
+    return np.array([x[1],-x[0], 0.0])
+
+exact_solution = Expression(
+    "sin(2 * DOLFIN_PI * x[0]) * cos(2 * DOLFIN_PI * x[1])",
+    degree=4
+)
+
+right_side_expression = Expression(
+    "8 * DOLFIN_PI * DOLFIN_PI * diffusivity\
+    * sin(2 * DOLFIN_PI * x[0]) * cos(2 * DOLFIN_PI * x[1])\
+    - 2 * DOLFIN_PI * x[1] * cos(2 * DOLFIN_PI * x[0])\
+    * cos(2 * DOLFIN_PI * x[1])\
+    - 2 * DOLFIN_PI * x[0] * sin(2 * DOLFIN_PI * x[0])\
+    * sin(2 * DOLFIN_PI * x[1])",
+    degree=2,
+    diffusivity=diffusivity
+)
+
+granularity = 8
+mesh = UnitCubeMesh(granularity, granularity, granularity)
+
+continuous_pw_linear_space = FunctionSpace(mesh, "Lagrange", 1)
+test_function = TestFunction(continuous_pw_linear_space)
+linear_functional = right_side_expression * test_function * dx
+
+stiffness_matrix = eafe.eafe(mesh, diffusion_expression, convection_expression)
+rhs_vector = assemble(linear_functional)
+
+bc = DirichletBC(continuous_pw_linear_space, exact_solution, boundary)
+bc.apply(stiffness_matrix, rhs_vector)
+
+solution = Function(continuous_pw_linear_space)
+solver = LUSolver(stiffness_matrix, "default")
+solver.parameters["symmetric"] = False
+solver.solve(solution.vector(), rhs_vector)
+
+solution_output = File("output/eafe.pvd")
+solution_output << solution
+
+if (errornorm(exact_solution, solution, 'l2', 3) > 2.12E-1):
+    print "L2 error increased! Solver failed"
+    exit(1)
+
+if (errornorm(exact_solution, solution, 'H1', 3) > 2.33E-0):
+    print "H1 error increased! Solver failed"
+    exit(1)
+
+print "L2 error = ", errornorm(exact_solution, solution, 'l2', 3)
+print "H1 error = ", errornorm(exact_solution, solution, 'H1', 3)
+print "Success!"

--- a/test/double_sin_reaction_test.py
+++ b/test/double_sin_reaction_test.py
@@ -1,0 +1,83 @@
+from dolfin import *
+import numpy as np
+import inspect
+import sys
+import os
+
+current_frame = inspect.getfile(inspect.currentframe())
+current_dir = os.path.dirname(os.path.abspath(current_frame))
+parent_dir = os.path.dirname(current_dir)
+sys.path.insert(0, parent_dir + "/src")
+import eafe
+
+
+def boundary(x, on_boundary):
+    return on_boundary
+
+diffusivity = 1.0E-2
+def diffusion_expression(x):
+    return diffusivity
+
+def convection_expression(x):
+    return np.array([x[1],-x[0]])
+
+reaction = 3.0
+def reaction_expression(x):
+    return reaction
+
+exact_solution = Expression(
+    "sin(2 * DOLFIN_PI * x[0]) * cos(2 * DOLFIN_PI * x[1])",
+    degree=4
+)
+
+right_side_expression = Expression(
+    "8 * DOLFIN_PI * DOLFIN_PI * diffusivity\
+    * sin(2 * DOLFIN_PI * x[0]) * cos(2 * DOLFIN_PI * x[1])\
+    - 2 * DOLFIN_PI * x[1] * cos(2 * DOLFIN_PI * x[0])\
+    * cos(2 * DOLFIN_PI * x[1])\
+    - 2 * DOLFIN_PI * x[0] * sin(2 * DOLFIN_PI * x[0])\
+    * sin(2 * DOLFIN_PI * x[1])\
+    + reaction * sin(2 * DOLFIN_PI * x[0])\
+    * cos(2 * DOLFIN_PI * x[1])",
+    degree=2,
+    diffusivity=diffusivity,
+    reaction=reaction
+)
+
+granularity = 8
+mesh = UnitSquareMesh(granularity, granularity)
+
+continuous_pw_linear_space = FunctionSpace(mesh, "Lagrange", 1)
+test_function = TestFunction(continuous_pw_linear_space)
+linear_functional = right_side_expression * test_function * dx
+
+stiffness_matrix = eafe.eafe(
+    mesh,
+    diffusion_expression,
+    convection_expression,
+    reaction_expression
+)
+rhs_vector = assemble(linear_functional)
+
+bc = DirichletBC(continuous_pw_linear_space, exact_solution, boundary)
+bc.apply(stiffness_matrix, rhs_vector)
+
+solution = Function(continuous_pw_linear_space)
+solver = LUSolver(stiffness_matrix, "default")
+solver.parameters["symmetric"] = False
+solver.solve(solution.vector(), rhs_vector)
+
+solution_output = File("output/eafe.pvd")
+solution_output << solution
+
+if (errornorm(exact_solution, solution, 'l2', 3) > 2.12E-1):
+    print "L2 error increased! Solver failed"
+    exit(1)
+
+if (errornorm(exact_solution, solution, 'H1', 3) > 2.33E-0):
+    print "H1 error increased! Solver failed"
+    exit(1)
+
+print "L2 error = ", errornorm(exact_solution, solution, 'l2', 3)
+print "H1 error = ", errornorm(exact_solution, solution, 'H1', 3)
+print "Success!"


### PR DESCRIPTION
Sorry to include more than one feature in this PR; but I've been sitting on these updates a while.  Should be pretty straightforward to review commit-by-commit. To summarize the updates:
 - The Bernoulli function has been moved outside the `eafe` function definition
 - Reaction terms are supported (evaluated by adding the corresponding lumped mass matrix, as prescribed in the original EAFE paper)
 - Additional safety steps have been taken to ensure discontinuous coefficients in the PDE are supported (by specifying the cell on which to evaluate the coefficient expression)
 - Additional test scripts with a reaction term and a 3d problem

### Notice
The updated formulae only evaluate the (diff & conv) coefficients on the element edges; the constant approximation at the  barycenter of a cell is replaced by a midpoint rule on each element edge.  As a result, the computed solution is slightly different from before; in all tests, the new computed is slightly more accurate, as the EAFE approximation is now slightly more accurate. (This change occurred in the last commit.)